### PR TITLE
[5874][FIX] sale_pricelist_global_rule

### DIFF
--- a/sale_pricelist_global_rule/models/sale_order.py
+++ b/sale_pricelist_global_rule/models/sale_order.py
@@ -46,7 +46,7 @@ class SaleOrder(models.Model):
                 pricelist_global_cummulative_quantity=qty_data
             )
             global_rule = self.env["product.pricelist.item"]
-            for line in sale.order_line:
+            for line in sale.order_line.filtered("product_id"):
                 suitable_rule = pricelist._get_product_rule(
                     line.product_id,
                     quantity=line.product_uom_qty or 1.0,


### PR DESCRIPTION
[5874](https://www.quartile.co/web?db=qrtl&token=z9OpY14OSBGGYn2qv0Ha#id=5874&menu_id=505&cids=3&action=1457&model=project.task&view_type=form)

If a sales order line without a product_id (section, memo, etc) is passed to _get_product_rule, it causes _compute_price_rule to return {}, which then triggers an error indicating that the product.id key is missing.

_compute_has_pricelist_global's _get_product_rule
https://github.com/qrtl/sfaj-oca/blob/2d72c9db365c8bd730cf290fb4dc184c3eed3b66/sale_pricelist_global_rule/models/sale_order.py#L50-L55

_get_product_rule in odoo/addons
https://github.com/odoo/odoo/blob/c27d978ade9bcbea056933d8fb8b5a924e983bde/addons/product/models/product_pricelist.py#L110-L111